### PR TITLE
Spruce up !play command with link to launch game, game banner image

### DIFF
--- a/config/default.yaml.example
+++ b/config/default.yaml.example
@@ -5,6 +5,8 @@ games:
   - name: "Rainbow Six Siege"
     minimumPlayers: 1
     maximumPlayers: 5
+    launcher:
+      steamAppId: 359550
     availableDays:
       - "Mon"
       - "Tue"
@@ -16,6 +18,8 @@ games:
   - name: "Rocket League"
     minimumPlayers: 1
     maximumPlayers: 3
+    launcher:
+      steamAppId: 252950
     availableDays:
       - "Mon"
       - "Tue"
@@ -27,6 +31,8 @@ games:
   - name: "CS:GO"
     minimumPlayers: 1
     maximumPlayers: 5
+    launcher:
+      steamAppId: 730
     availableDays:
       - "Mon"
       - "Tue"

--- a/lib/commands/play.js
+++ b/lib/commands/play.js
@@ -1,12 +1,27 @@
-import { chooseGame } from '../game-chooser'
+import { chooseGame, launcherForGame } from '../game-chooser'
+import { RichEmbed } from 'discord.js'
+
 export const play = {
   name: 'Play',
   help: 'Chooses a game to play when everyone is just a bit too indecisive',
   usage: '!play',
   execute (client, message) {
-    const game = chooseGame(client)
+    const game = chooseGame(client, message.member.guild.id)
     if (game) {
-      message.channel.send(`You should play ${game.name}`)
+      const launcher = launcherForGame(game)
+
+      // If we have game launcher details, we can build a rich embed with
+      // a banner image, and a link to directly open the game on steam:
+      if (launcher) {
+        const embed = new RichEmbed()
+
+        embed.setTitle(game.name)
+             .setImage(launcher.banner)
+
+        message.channel.send(`You should play **${game.name}**: ${launcher.url}`, embed)
+      } else {
+        message.channel.send(`You should play ${game.name}`)
+      }
     } else {
       message.channel.send('I don\'t know, whatever you feel like...')
     }

--- a/lib/game-chooser.js
+++ b/lib/game-chooser.js
@@ -2,10 +2,24 @@ import { activeUsers } from './users'
 import config from 'config'
 import { sample } from 'lodash'
 
-export function chooseGame (client) {
-  const userCount = activeUsers(client)
+export function chooseGame (client, guildId) {
+  const userCount = activeUsers(client, guildId)
   const games = config.get('games')
   return filterGames(games, userCount)
+}
+
+export function launcherForGame (game) {
+  const launcher = game.launcher
+  if (!launcher) return null
+
+  if (launcher.steamAppId) {
+    return {
+      banner: `https://steamcdn-a.akamaihd.net/steam/apps/${launcher.steamAppId}/header.jpg`,
+      url: `steam://rungameid/${launcher.steamAppId}`
+    }
+  } else {
+    throw new Error(`Don't know how to gather launcher details for ${game.name} (${launcher})`)
+  }
 }
 
 function filterGames (games, numberOfPlayers) {

--- a/lib/users.js
+++ b/lib/users.js
@@ -10,7 +10,7 @@ export function isOnline (member) {
   return member.presence.status === 'online'
 }
 
-export function activeUsers (client) {
-  const numberOfUsers = client.guilds.get('505065602021589003').members.filter(member => isNotBot(member) && isOnline(member)).size
+export function activeUsers (client, guildId) {
+  const numberOfUsers = client.guilds.get(guildId).members.filter(member => isNotBot(member) && isOnline(member)).size
   return numberOfUsers === 0 ? 1 : numberOfUsers
 }


### PR DESCRIPTION
This PR adds a banner image for the selected game when running the `!play` command, as well as a steam protocol link to directly launch the game:

![image](https://user-images.githubusercontent.com/382538/47682231-ad748380-dbc3-11e8-9ee6-3076d2e8549d.png)

This behaviour is optional, and is enabled by adding a `launcher` section to the available games list:

```yaml
games:
  - name: Barbie™ Dreamhouse Party™
    # ... other stuff ...
    launcher:
      steamAppId: 251610
```

There's only support for steam games at the moment, but support for other platforms can be easily added by adding additional keys (e.g originGameId, battlenetGameId).

If the launcher section is missing, the current behaviour is used instead.

**NOTE**: This could be made nicer by making the game banner clickable to directly launch the game, unfortunately discord limits a lot of the linking stuff (e.g rich embed URLs, markdown links) to those starting with `http://` and `https://` only.

--- 

Additionally, also:
- Removes the hard-coded guild ID when collecting active users, and fetches it from the origin message instead