### PR TITLE
Dice roll command

### DIFF
--- a/lib/commands/misc.js
+++ b/lib/commands/misc.js
@@ -2,6 +2,10 @@ import { map } from 'lodash'
 import config from 'config'
 import * as commands from './'
 import { activeUsers } from '../users'
+import { rollDiceFromStrings } from '../roll'
+
+// Markdown code block boundary, interpolate it as needed
+const block = '```'
 
 export const ping = {
   name: 'Ping',
@@ -11,6 +15,23 @@ export const ping = {
     message.channel.send('Pong')
   }
 }
+
+export const roll = {
+  name: 'Roll',
+  help: 'Rolls one or more dice of various types',
+  usage: '!roll 2xd20 d4 2xd10',
+  execute (client, message) {
+    const rolls = message.content.split(' ').slice(1)
+    const results = rollDiceFromStrings(rolls)
+
+    const resultsBody = results.map(r => {
+      return `${r.die} x ${r.count}: ${r.results.join(', ')}`
+    })
+
+    message.channel.send(`Here you go:\n\n${block}\n\n${resultsBody.join('\n')}\n\n${block}`)
+  }
+}
+
 export const users = {
   name: 'Users',
   help: 'Returns the current online user count, users that are away or in do not disturb mode will not be counted',

--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -3,5 +3,5 @@ export function messageIsACommand (message) {
 }
 
 export function getMessageCommand (message) {
-  return message.content.substr(1).split()[0]
+  return message.content.substr(1).split(' ')[0]
 }

--- a/lib/roll.js
+++ b/lib/roll.js
@@ -1,0 +1,38 @@
+import { times, random } from 'lodash'
+
+const rollPattern = /((\d+)x)?d(\d+)/i
+const roller = (die) => {
+  // Returns a positive, non-zero random integer
+  return () => random(die) || 1
+}
+
+// Given an array of strings, parses said strings into rolls, and
+// returns a list with the results
+//
+// Example input:
+//  ['d20', '2xd4']
+//
+// Example output:
+//  [
+//   { roll: 'd20', results: [18] },
+//   { roll: '2xd4', results: [4, 2] }
+//  ]
+export function rollDiceFromStrings (rolls) {
+  return rolls.map(roll => {
+    const parts = roll.match(rollPattern)
+
+    if (!parts) {
+      return { roll, results: [] }
+    }
+
+    const die = Math.min(parseInt(parts[3] || 0), 9999)
+    const count = Math.min(parseInt(parts[2] || 1), 15)
+
+    return {
+      roll,
+      die: `d${die}`,
+      count: count,
+      results: times(count, roller(die))
+    }
+  })
+}


### PR DESCRIPTION
Adds a simple dice roll command. Supports multiple types of dice, and multiple rolls per dice.

Command: 

```
!roll d20 2xd10 4xd4
```

Result:

```
d20 x 1: 14
d10 x 2: 8, 4
d4 x 4: 1, 3, 4, 1
```


