### PR TITLE
Add '>' shortcut for say commands

### DIFF
--- a/lib/commands/voice.js
+++ b/lib/commands/voice.js
@@ -2,6 +2,16 @@ import { playSampleInVoiceChannel, isValidSample, listSamples } from '../voice'
 
 const samplePattern = /!say ([\w\d]+)/
 
+export async function playSampleIfExists (sampleName, message) {
+  if (isValidSample(sampleName)) {
+    await playSampleInVoiceChannel(sampleName, message.member.voiceChannel)
+  } else {
+    message.channel.send(`Sorry, I'm not familiar with that sample`)
+  }
+
+  message.delete()
+}
+
 export const say = {
   name: 'Say',
   help: 'Tells the bot to say something in your voice channel',
@@ -15,13 +25,7 @@ export const say = {
     if (!sampleMatch) return null
 
     const sampleName = sampleMatch[1]
-
-    if (isValidSample(sampleName)) {
-      await playSampleInVoiceChannel(sampleName, message.member.voiceChannel)
-    } else {
-      message.channel.send(`Sorry, I'm not familiar with that sample`)
-    }
-    message.delete()
+    await playSampleIfExists(sampleName, message)
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 import config from 'config'
 import { messageIsACommand, getMessageCommand } from './messaging'
 import { loadSamples } from './voice'
+import { playSampleIfExists } from './commands/voice'
 import * as commands from './commands'
 
 const token = config.get('botToken')
@@ -18,7 +19,9 @@ client.on('ready', async () => {
 client.login(token)
 
 client.on('message', async message => {
-  if (messageIsACommand(message)) {
+  if (message.content[0] === '>') {
+    await playSampleIfExists(message.content.substr(1).split(' ')[0], message)
+  } else if (messageIsACommand(message)) {
     const command = getMessageCommand(message)
     if (command in commands) {
       await commands[command].execute(client, message)


### PR DESCRIPTION
Instead of using `!say sample` all the time, this PR allows you to use `>samplename` instead.
